### PR TITLE
fix/#138: fix skip button action in GameCategoryAdd

### DIFF
--- a/omokwan/Projects/Presentation/Main/Sources/Coordinator/Navigation/MainNavigation.swift
+++ b/omokwan/Projects/Presentation/Main/Sources/Coordinator/Navigation/MainNavigation.swift
@@ -31,8 +31,8 @@ extension MainCoordinatorFeature {
         case .navigateToBack:
             _ = state.path.popLast()
             return .none
-        case .skipButtonTapped(let category):
-            state.path.append(.myGameAdd(MyGameAddFeature.State(selectedCategory: category)))
+        case .skipButtonTapped:
+            state.path.append(.myGameAdd(MyGameAddFeature.State(selectedCategory: nil)))
             return .none
         case .nextButtonTapped(let category):
             state.path.append(.myGameAdd(MyGameAddFeature.State(selectedCategory: category)))

--- a/omokwan/Projects/Presentation/MyGameAdd/Sources/MyGameAddCategory/MyGameAddCategoryFeature.swift
+++ b/omokwan/Projects/Presentation/MyGameAdd/Sources/MyGameAddCategory/MyGameAddCategoryFeature.swift
@@ -22,7 +22,7 @@ public struct MyGameAddCategoryFeature: Reducer {
     }
     
     public enum Action {
-        case skipButtonTapped(GameCategory?)
+        case skipButtonTapped
         case nextButtonTapped(GameCategory?)
         case categoryTapped(GameCategory)
         case navigateToBack

--- a/omokwan/Projects/Presentation/MyGameAdd/Sources/MyGameAddCategory/MyGameAddCategoryView.swift
+++ b/omokwan/Projects/Presentation/MyGameAdd/Sources/MyGameAddCategory/MyGameAddCategoryView.swift
@@ -81,7 +81,7 @@ public struct MyGameAddCategoryView: View {
                 type: .text,
                 size: .small,
                 action: {
-                    viewStore.send(.skipButtonTapped(viewStore.selectedCategory))
+                    viewStore.send(.skipButtonTapped)
                 }
             )
             OButton(


### PR DESCRIPTION
대국 만들기 > 카테고리 > 건너뛰기를 클릭했음에도, 다음 페이지에서 카테고리에 대한 정보를 들고 있는 문제 해결